### PR TITLE
Add support for 480x480 87ad:70db ChiZhu Tech USBDISPLAY

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,3 @@ dependencies = [
 
 [project.scripts]
 application-name = "thermalright_lcd_control.main:main"
-
-/home/rbenrejeb/IdeaProjects/thermalright-lcd-control/releases

--- a/resources/gui_config.yaml
+++ b/resources/gui_config.yaml
@@ -30,5 +30,5 @@ supported_devices:
 
   - vid: "87ad"
     pid: "70db"
-    width: 320
-    height: 320
+    width: 480
+    height: 480

--- a/src/thermalright_lcd_control/device_controller/display/device_loader.py
+++ b/src/thermalright_lcd_control/device_controller/display/device_loader.py
@@ -4,12 +4,12 @@ import usb.core
 
 from .display_device import DisplayDevice
 from .hid_devices import DisplayDevice04185304, DisplayDevice04165302
-from .usb_devices import DisplayDevice87AD70DB
+from .usb_devices import DisplayDevice87AD70DB, DisplayDevice87AD70DB480
 
 SUPPORTED_DEVICES = [
     (0x0418, 0x5304, DisplayDevice04185304),
     (0x0416, 0x5302, DisplayDevice04165302),
-    (0x87AD, 0x70DB, DisplayDevice87AD70DB),
+    (0x87AD, 0x70DB, DisplayDevice87AD70DB480),  # Updated to use 480x480 JPEG variant
     # (vid, pid, Your new device class here ),
 ]
 


### PR DESCRIPTION
Adds support for the 480x480 87ad:70db ChiZhu Tech USBDISPLAY device (as present on the Grand Vision line). Currently a WIP, I plan to add support for both the 320x320 display and 480x480 display simutaniously. In the meantime, you may pull from this pull request if you have the same device as mine.

This pr also fixes incorrectly pasted text in pyproject.toml.